### PR TITLE
Catch errors when loading the CRN module.

### DIFF
--- a/src/CompressedTextureManager.js
+++ b/src/CompressedTextureManager.js
@@ -16,7 +16,7 @@ CompressedTextureManager.prototype = Object.create(WebGLManager.prototype);
 CompressedTextureManager.prototype.constructor = CompressedTextureManager;
 
 CompressedTextureManager.prototype.onContextChange = function() {
-    const gl = this.renderer.gl;
+    var gl = this.renderer.gl;
     function getExtension(gl, name) {
         var vendorPrefixes = ["", "WEBKIT_", "MOZ_"];
         var ext = null;

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,6 @@ var plugin = {
     extensionChooser: require('./extensionChooser'),
     extensionFixer: require('./extensionFixer'),
     GLTextureMixin: require('./GLTextureMixin'),
-    crn: require('./../lib/crn_decomp'),
     detectExtensions: function (renderer, resolution) {
         var extensions = [];
         if (renderer instanceof PIXI.WebGLRenderer) {
@@ -31,6 +30,14 @@ var plugin = {
         return extensions;
     }
 };
+
+try {
+    plugin.crn = require('./../lib/crn_decomp');
+} catch (e) {
+    //oh well, couldn't require it - probably due to eval() not being allowed in whatever context
+    //we are loaded in
+    console.warn('Unable to load crn decompression in pixi-compressed-textures');
+}
 
 Object.assign(PIXI.glCore.GLTexture.prototype, plugin.GLTextureMixin);
 


### PR DESCRIPTION
The CRN decompression code includes `eval()`, which throws errors if the security settings for a site forbids its usage (Atom is set up to do this as well). I've wrapped the `require()` of it with a try/catch so that the rest of the code can continue to function.

I also swapped out `const` for `var` because the linter was complaining.