### PR TITLE
ASTC (RGBA) textures loading

### DIFF
--- a/src/CompressedTextureManager.js
+++ b/src/CompressedTextureManager.js
@@ -32,6 +32,7 @@ CompressedTextureManager.prototype.onContextChange = function() {
     this.extensions = {
         dxt: getExtension(gl, "WEBGL_compressed_texture_s3tc"),
         pvrtc: getExtension(gl, "WEBGL_compressed_texture_pvrtc"),
+        astc: getExtension(gl, "WEBGL_compressed_texture_astc"),
         atc: getExtension(gl, "WEBGL_compressed_texture_atc")
     };
     // CRN exists only with DXT!

--- a/src/imageParser.js
+++ b/src/imageParser.js
@@ -7,10 +7,11 @@ Resource.setExtensionXhrType('dds', Resource.XHR_RESPONSE_TYPE.BUFFER);
 Resource.setExtensionXhrType('crn', Resource.XHR_RESPONSE_TYPE.BUFFER);
 Resource.setExtensionXhrType('pvr', Resource.XHR_RESPONSE_TYPE.BUFFER);
 Resource.setExtensionXhrType('etc1', Resource.XHR_RESPONSE_TYPE.BUFFER);
+Resource.setExtensionXhrType('astc', Resource.XHR_RESPONSE_TYPE.BUFFER);
 
 function imageParser() {
     return function (resource, next) {
-        if (resource.url.indexOf('.crn') != -1 || resource.url.indexOf('.dds') != -1 || resource.url.indexOf('.pvr') != -1 || resource.url.indexOf('.etc1') != -1) {
+        if (resource.url.indexOf('.crn') != -1 || resource.url.indexOf('.dds') != -1 || resource.url.indexOf('.pvr') != -1 || resource.url.indexOf('.etc1') != -1 || resource.url.indexOf('.astc')!= -1) {
             var compressedImage = resource.compressedImage || new CompressedImage(resource.url);
             if (resource.data) {
                 throw "compressedImageParser middleware must be specified in loader.before() and must have zero resource.data";

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ var plugin = {
             if (data.dxt) extensions.push('.dds');
             if (data.pvrtc) extensions.push('.pvr');
             if (data.atc) extensions.push('.atc');
+            if (data.astc) extensions.push('.astc');
         } else if (renderer instanceof PIXI.CanvasRenderer) {
             //nothing special for canvas
         }


### PR DESCRIPTION
Hi,
I wrote a commit that enables load of ASTC encoded textures.
Support of ASTC is rising since its Khronos standardization in 2012. According to [webglstats](https://webglstats.com/webgl/extension/WEBGL_compressed_texture_astc) it is supported on 28% smartphones.

I encoutered two problems:
1) According to [stackoverflow thread](https://stackoverflow.com/questions/22600678/determine-internal-format-of-given-astc-compressed-image-through-its-header) it is impossible to determine compresion type from astc file header. I detect blocksize by data length and presume RGBA color space (no support for SRGB8)
2) [ASTC-encoder](https://github.com/ARM-software/astc-encoder) that seems like a natural choice for encoding is using top-left instead of bottom-left coordinates. Simplest solution is to flip the image vertically before encoding.

I made a simple [example](http://adasek.cz/pixi-compressed-astc-example/). Tested on Android phone.

I would be glad for your feedback. 