### PR TITLE
Fixing pureExt wrong for file@0.5x.ext due to dot in format specifier

### DIFF
--- a/src/extensionChooser.js
+++ b/src/extensionChooser.js
@@ -28,8 +28,16 @@ function extensionChooser(supportedExtensions) {
                     resource.url = url;
 
                     var pureExt = ext[i];
-                    k = ext[i].indexOf('.');
-                    if (k>=0) pureExt = ext[i].substring(k+1);
+                    if (pureExt.indexOf('@') > -1){
+                        //@0.5x.dds should have pureExt "dds", not 5x.dds
+                        // -> remove format specifier (@2x, @0.5x) before
+                        //determining the extension
+                        pureExt=pureExt.replace(/@[0-9.]*x/,""); 
+                    }
+                    k = pureExt.indexOf('.');
+                    if (k >= 0){
+                        pureExt = pureExt.substring(k+1);
+                    }
 
                     resource.extension = pureExt;
                     resource.loadType = resource._determineLoadType();


### PR DESCRIPTION
I had a problem with half-size textures @0.5x loading.
It seems that pureExt determination was improperly splitting the name by the first dot it sees - "_texture@0.5x.dds_" was returning pureExt string "_5x.dds_" instead of correct "_dds_".

I attempt to fix it in the most backward-compatible manner - only removing /@[0-9.]x/ from filename before determining pureExt.