### PR TITLE
browserify-versionify dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,10 +43,10 @@
     "README.md"
   ],
   "dependencies": {
-    "glslify": "^5.0.2"
+    "glslify": "^5.0.2",
+    "browserify-versionify": "^1.0.6"
   },
   "devDependencies": {
-    "browserify-versionify": "^1.0.6",
     "del": "^2.2.0",
     "jaguarjs-jsdoc": "^1.0.1",
     "jsdoc": "^3.4.0",


### PR DESCRIPTION
* moving browserify-versionify to a regular dependency instead of a devDependency in the package.json file.  This is to fix the case where a project uses pixi-compressed-textures and also uses browserify.  The new project will observe the browserify#transform field in the pixi-compressed-textures package.json file and try to use the browserify-versionify package.  It will fail because this package won't be installed when listed as a devDependency.