### PR TITLE
Add etc1 support

### DIFF
--- a/src/CompressedTextureManager.js
+++ b/src/CompressedTextureManager.js
@@ -33,7 +33,8 @@ CompressedTextureManager.prototype.onContextChange = function() {
         dxt: getExtension(gl, "WEBGL_compressed_texture_s3tc"),
         pvrtc: getExtension(gl, "WEBGL_compressed_texture_pvrtc"),
         astc: getExtension(gl, "WEBGL_compressed_texture_astc"),
-        atc: getExtension(gl, "WEBGL_compressed_texture_atc")
+        atc: getExtension(gl, "WEBGL_compressed_texture_atc"),
+        etc1: getExtension(gl, "WEBGL_compressed_texture_etc1")
     };
     // CRN exists only with DXT!
     this.extensions.crn = this.extensions.dxt;

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ var plugin = {
             if (data.pvrtc) extensions.push('.pvr');
             if (data.atc) extensions.push('.atc');
             if (data.astc) extensions.push('.astc');
+            if (data.etc1) extensions.push('.etc1');
         } else if (renderer instanceof PIXI.CanvasRenderer) {
             //nothing special for canvas
         }


### PR DESCRIPTION
Like the [issue here](https://github.com/pixijs/pixi-compressed-textures/issues/15), I also wanted to use the etc1 format, so I fixed it.
I confirmed that etc1 texture can be rendered on Android.

If it looks good, please pull this.